### PR TITLE
Fix TypeScript typings: default initializers are only allowed in implementations.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,14 +4,10 @@
 declare class Duration {
 	constructor(
 		lang: Intl.BCP47LanguageTag,
-		options?: Intl.RelativeTimeFormatOptions = {
-			numeric = "auto",
-			localeMatcher = "best fit",
-			style = "long"
-		}
+		options?: Intl.RelativeTimeFormatOptions
 	);
 
-	format(d1: string | number | Date, d2?: string | number | Date = new Date()): string;
+	format(d1: string | number | Date, d2?: string | number | Date): string;
 }
 
 export = Duration;


### PR DESCRIPTION
The existing typings cause compilation failures when this library is used, as default values aren't allowed in typing files (only in actual TS/JS implementations).